### PR TITLE
Bugfix label condition in jgf loader.

### DIFF
--- a/src/game/node.service.js
+++ b/src/game/node.service.js
@@ -213,7 +213,7 @@ angular.module('ngGo.Game.Node.Service', [
 			}
 
 			//Label?
-			if (type == 'LB') {
+			if (type == 'label') {
 				jgfMarkup[type].push([markup[i].x, markup[i].y, markup[i].text]);
 			}
 			else {


### PR DESCRIPTION
Fixes a bug in JGF loader that text labels won't be displayed after Player.load(JGF). The bug only appears if the new JGF markup is used.